### PR TITLE
Fix realtime livetracker: request params, Arrow serialisation, chart …

### DIFF
--- a/rowing/world_rowing/api.py
+++ b/rowing/world_rowing/api.py
@@ -305,7 +305,8 @@ def prepare_request(*endpoints, **kwargs):
 
 
 def request_worldrowing(*endpoints, request_kws=None, **kwargs):
-    return _session.get(*prepare_request(*endpoints, **kwargs), **dict(request_kws or {}))
+    url, params = prepare_request(*endpoints, **kwargs)
+    return _session.get(url, params=params, **dict(request_kws or {}))
 
 
 def request_worldrowing_json(*endpoints, request_kws=None, **kwargs):

--- a/rowing/world_rowing/pages/realtime.py
+++ b/rowing/world_rowing/pages/realtime.py
@@ -34,7 +34,8 @@ def main(params=None):
     with st.sidebar:
         with st.expander("Settings"):
             realtime_sleep = st.number_input("poll", 0.0, 10.0, 3.0, step=0.5)
-            replay = st.checkbox("replay race data", st.session_state.get("replay_race", False), key="replay_race")
+            replay = st.checkbox("replay race data", st.session_state.get(
+                "replay_race", False), key="replay_race")
             replay_step = st.number_input("replay step", 1, 100, 10)
             replay_start = st.number_input("replay step", 0, 1000, 0)
 
@@ -48,11 +49,16 @@ def main(params=None):
     with st.expander("Last Races"):
         n_races = st.number_input("Load how many races?", 0, value=0, step=1)
         if n_races > 0:
-            races, race_boats, intermediates = select.last_race_results(n_races, fisa=False, cached=False)
-            race_order = races.sort_values("Race Start").Race
-            order = race_order[race_order.isin(intermediates["Race"])].drop_duplicates()
-            race_lanes = intermediates.groupby(["Race", "Lane"])["Boat"].first().sort_index()
-            race_inters = intermediates.groupby(["Race", "Distance", "Boat"])["ResultTime"].first()
+            races, race_boats, intermediates = select.last_race_results(
+                n_races, fisa=False, cached=False)
+            race_order = races.sort_values(
+                "Race Start", ascending=False).Race
+            order = race_order[race_order.isin(
+                intermediates["Race"])].drop_duplicates()
+            race_lanes = intermediates.groupby(["Race", "Lane"])[
+                "Boat"].first().sort_index()
+            race_inters = intermediates.groupby(["Race", "Distance", "Boat"])[
+                "ResultTime"].first()
             for race in order:
                 st.write(f"##### {race}")
                 lane_order = race_lanes.loc[race]
@@ -74,7 +80,9 @@ def main(params=None):
     with race_expander:
         race = select.select_live_race(replay, **kwargs)
         if st.toggle("## Race details", True):
-            st.dataframe(race, width="stretch")
+            # race is a Series of mixed-type fields; cast to str so its single object column is
+            # Arrow-serialisable (otherwise Streamlit logs a conversion warning every render).
+            st.dataframe(race.astype(str), width="stretch")
 
         if st.toggle("## Crew lists", True):
             st.dataframe(select.get_crewlist(race.race_id))
@@ -86,11 +94,14 @@ def main(params=None):
             if boat_class:
                 st.markdown("#### Details:")
                 st.dataframe(
-                    select.fields.to_streamlit_dataframe(wbts).T,
+                    # transpose makes each record an object column (str labels + numeric values);
+                    # cast to str so Arrow can serialise it (this is a display-only details table).
+                    select.fields.to_streamlit_dataframe(wbts).T.astype(str),
                     # width="stretch"
                 )
 
-            fastest_id = wbts.loc[wbts["Best Time"].idxmin(), "bestTimes_RaceId"]
+            fastest_id = wbts.loc[wbts["Best Time"].idxmin(),
+                                  "bestTimes_RaceId"]
             inters = select.get_race_intermediates(fastest_id)
             if not inters.empty:
                 st.markdown("#### Intermediates:")
@@ -99,7 +110,8 @@ def main(params=None):
     state.reset_button()
 
     with live_container:
-        st.subheader("Livetracker")
+        st.subheader(
+            f"{race.competition} - {race[select.fields.Race]} - Livetracker")
 
         live_race = select.get_live_race_data(
             race.race_id,
@@ -144,11 +156,13 @@ def main(params=None):
 
             with show_intermediates:
                 if not live_race.lane_info.empty:
-                    plots.show_lane_intermediates(live_race.lane_info, live_race.intermediates)
+                    plots.show_lane_intermediates(
+                        live_race.lane_info, live_race.intermediates)
 
             with fig_plot:
                 if fig is not None:
                     fig = plots.update_figure(fig, **fig_params)
+                    fig.update_layout(title=race[select.fields.Race])
                     st.plotly_chart(fig, width="stretch", key=time.time())
                 else:
                     st.write("no live data could be loaded")

--- a/test_rowing/test_api_request.py
+++ b/test_rowing/test_api_request.py
@@ -1,0 +1,34 @@
+"""Offline regression tests for the request plumbing in rowing.world_rowing.api.
+
+The live-API tests in test_api.py are network-gated, so a bug in how the shared session is
+*called* (e.g. passing params positionally) would never be caught offline. These tests stub the
+session and assert the call shape only -- no network.
+"""
+
+from rowing.world_rowing import api
+
+
+def test_request_worldrowing_passes_params_as_keyword(monkeypatch):
+    # FakeSession.get mirrors requests.Session.get: only `url` is positional. If request_worldrowing
+    # regresses to _session.get(url, params) the positional params raises TypeError here.
+    calls = {}
+
+    class FakeSession:
+        def get(self, url, **kwargs):
+            calls["url"] = url
+            calls["kwargs"] = kwargs
+            return "RESPONSE"
+
+    monkeypatch.setattr(api, "_session", FakeSession())
+
+    out = api.request_worldrowing("livetracker", "race-123", competition="abc")
+
+    assert out == "RESPONSE"
+    assert calls["url"].endswith("/livetracker/race-123")
+    assert "params" in calls["kwargs"]  # params must be a keyword, not the 2nd positional arg
+
+
+def test_prepare_request_builds_url_and_params():
+    url, params = api.prepare_request("livetracker", "race-123")
+    assert url.endswith("/stats/api/livetracker/race-123")
+    assert params is None  # no query kwargs -> None (so Session.get omits params)


### PR DESCRIPTION
…title

request_worldrowing splatted prepare_request()'s (url, params) into Session.get, passing params as a 2nd positional arg -> 'Session.get() takes 2 positional arguments but 3 were given', which broke live tracking (live.py get_livetracker). Pass params as a keyword. Add an offline regression test (test_api_request.py) since the live-API tests are network-gated and never caught it.

Realtime page: cast the race-details Series to str so its mixed-type object column is Arrow-serialisable (was logging a conversion warning every render); same hardening on the transposed world-best-time details table. Add the race name to the live chart title and the competition/race to the Livetracker subheader.