### PR TITLE
Fix livetracker estimate for pandas 2.x string distance labels

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -50,3 +50,20 @@ jobs:
       # Network tests are deselected by default (conftest skips them unless
       # --run-network is passed).
       run: pytest --cov=rowing --cov-report=term-missing
+
+  network-test:
+    # Live World Rowing API integration tests (request plumbing + the livetracker pipeline).
+    # Run once, on the latest supported Python. Hits the live API, so it can be flaky if the
+    # service is down -- relax to `continue-on-error: true` if that becomes a nuisance.
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - name: Install package with all extras
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -e .[all,dev]
+    - name: Run live-API tests
+      run: pytest -m network --run-network

--- a/rowing/world_rowing/live.py
+++ b/rowing/world_rowing/live.py
@@ -151,6 +151,12 @@ def estimate_livetracker_times(live_boat_data, intermediates, lane_info, race_di
         intermediate_times = intermediates.dropna(how="all", axis=1)[fields.intermediates_ResultTime].apply(
             lambda s: s.dt.total_seconds()
         )
+        # The distance index is labels like "d500m"; extract the numeric distance so comparisons
+        # against the numeric distanceTravelled below work (pandas 2.x raises on numeric-vs-str
+        # comparisons, where older pandas silently returned all-False and skipped the correction).
+        intermediate_times.index = pd.to_numeric(
+            intermediate_times.index.astype(str).str.extract(r"(\d+)")[0], errors="coerce"
+        ).values
         intermediate_distances = intermediate_times.index.values
 
     live_data = live_boat_data.loc[live_boat_data[fields.live_trackCount].min(axis=1).sort_values().index].reset_index(drop=True)

--- a/test_rowing/test_api.py
+++ b/test_rowing/test_api.py
@@ -1,9 +1,9 @@
 import pytest
 
 from rowing.utils import timeout
-from rowing.world_rowing import api
+from rowing.world_rowing import api, live
 
-TIMEOUT = 30
+TIMEOUT = 60
 
 # Every test in this module hits the live World Rowing API.
 pytestmark = pytest.mark.network
@@ -47,3 +47,30 @@ def test_get_stats():
     api.get_venues()
     api.get_competition_best_times()
     api.get_world_best_times()
+
+
+@timeout(TIMEOUT)
+def test_livetracker_pipeline():
+    # End-to-end livetracker path used by the livetracker page: load_livetracker (request plumbing)
+    # + estimate_livetracker_times (numeric coercion of the "d500m" distance labels). Catches both
+    # the request_worldrowing params regression and the numeric-vs-str comparison regression.
+    competitions = api.get_competitions(2021)
+    competition = competitions[competitions.competition_id == "e807bba5-6475-4f1a-9434-26704585bf19"].iloc[0]
+    races = api.get_races(competition.competition_id)
+    race_ids = races.race_id.iloc[:8]
+
+    # Direct estimate on a real race -> raises if estimate_livetracker_times regresses (the batch
+    # path below swallows per-race errors, so test the function directly for a strong guard).
+    for race_id in race_ids:
+        live_boat_data, intermediates, lane_info, race_distance = live.load_livetracker(race_id, cached=False)
+        if not live_boat_data.empty:
+            out = live.estimate_livetracker_times(live_boat_data, intermediates, lane_info, race_distance)
+            live_data = out[0] if isinstance(out, tuple) else out
+            assert len(live_data) > 0
+            break
+    else:
+        pytest.skip("no livetracker data for the sampled races")
+
+    # batch path used by the app
+    live_data, intermediates, lane_info = live.get_races_livetracks(race_ids)
+    assert not live_data.empty


### PR DESCRIPTION
live.estimate_livetracker_times compared the intermediate-distance index (labels like 'd500m') against the numeric distanceTravelled. Older pandas returned all-False (the intermediate correction silently no-op'd); pandas 2.x raises 'Invalid comparison between dtype=int64 and str', which broke the livetracker page. Extract the numeric distance from the labels before comparing.

Tests: offline regression (test_live.py) on a captured fixture with 'd500m' labels (fails without the fix), plus a network-gated end-to-end livetracker pipeline test in test_api.py that exercises load_livetracker + estimate_livetracker_times (would also catch the request_worldrowing params regression).